### PR TITLE
Add BindableProperty ItemsSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,37 @@ xmlns:plugin="clr-namespace:TabStrip.FormsPlugin.Abstractions;assembly=TabStrip.
 Add the control:
 
 ```xml
-<plugin:TabStripControl Position="{Binding CurrentPosition}" />
+<plugin:TabStripControl Position="{Binding CurrentPosition}"
+						ItemsSource="{Binding Views}" />
+```
+
+Add the following code to your BindingContext. The `ItemsSource` property needs to be mapped to an `IEnumerable<TabModel>` where `TabModel` is provided in the `TabStrip.FormsPlugin.Abstractions` namespace.
+```c#
+BindingContext = new 
+{
+	Views = new ObservableCollection<TabModel>(new [] 
+	{
+		new TabModel
+        {
+            Name = "Tab 1",
+            View = (new HelloView(), new HelloPageModel())
+        },
+        new TabModel
+        {
+            Name = "Tab 2",
+            View = (new HelloView(), new HelloPageModel())
+        }
+
+	});
+};
 ```
 
 ## Bindable Properties
 
-| Property | Description                                                        | Default Value |
-|----------|--------------------------------------------------------------------|---------------|
-| Position | Gets or Sets current tab position of the tab strip.                | 0             |
+| Property    | Description                                                                                                                         | Default Value |
+|-------------|-------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| Position    | Gets or Sets current tab position of the tab strip.                                                                                 | `0`             |
+| ItemsSource | Gets or Sets the `IEnumerable<TabModel>` where the `TabModel` defines the Tab Name and the View/ViewModel relationship for each Tab | `null`          |
 
 ## Release Notes
 

--- a/Sample/TabStrip.Sample.Android/TabStrip.Sample.Android.csproj
+++ b/Sample/TabStrip.Sample.Android/TabStrip.Sample.Android.csproj
@@ -50,10 +50,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CarouselView.FormsPlugin.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.70\lib\MonoAndroid10\CarouselView.FormsPlugin.Abstractions.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.75\lib\MonoAndroid10\CarouselView.FormsPlugin.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="CarouselView.FormsPlugin.Android, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.70\lib\MonoAndroid10\CarouselView.FormsPlugin.Android.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.75\lib\MonoAndroid10\CarouselView.FormsPlugin.Android.dll</HintPath>
     </Reference>
     <Reference Include="FormsViewGroup, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Xamarin.Forms.2.4.0.18342\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
@@ -65,10 +65,10 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
     <Reference Include="TabStrip.FormsPlugin.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.70\lib\MonoAndroid10\TabStrip.FormsPlugin.Abstractions.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.75\lib\MonoAndroid10\TabStrip.FormsPlugin.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="TabStrip.FormsPlugin.Android, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.70\lib\MonoAndroid10\TabStrip.FormsPlugin.Android.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.75\lib\MonoAndroid10\TabStrip.FormsPlugin.Android.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Animated.Vector.Drawable, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.26.0.2\lib\MonoAndroid80\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>

--- a/Sample/TabStrip.Sample.Android/packages.config
+++ b/Sample/TabStrip.Sample.Android/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="TabStrip" version="1.0.70" targetFramework="monoandroid80" />
+  <package id="TabStrip" version="1.0.75" targetFramework="monoandroid80" />
   <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="26.0.2" targetFramework="monoandroid80" />
   <package id="Xamarin.Android.Support.Annotations" version="26.0.2" targetFramework="monoandroid80" />
   <package id="Xamarin.Android.Support.Compat" version="26.0.2" targetFramework="monoandroid80" />

--- a/Sample/TabStrip.Sample.iOS/TabStrip.Sample.iOS.csproj
+++ b/Sample/TabStrip.Sample.iOS/TabStrip.Sample.iOS.csproj
@@ -122,19 +122,19 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="CarouselView.FormsPlugin.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.70\lib\Xamarin.iOS10\CarouselView.FormsPlugin.Abstractions.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.75\lib\Xamarin.iOS10\CarouselView.FormsPlugin.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="CarouselView.FormsPlugin.iOS, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.70\lib\Xamarin.iOS10\CarouselView.FormsPlugin.iOS.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.75\lib\Xamarin.iOS10\CarouselView.FormsPlugin.iOS.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="TabStrip.FormsPlugin.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.70\lib\Xamarin.iOS10\TabStrip.FormsPlugin.Abstractions.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.75\lib\Xamarin.iOS10\TabStrip.FormsPlugin.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="TabStrip.FormsPlugin.iOS, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.70\lib\Xamarin.iOS10\TabStrip.FormsPlugin.iOS.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.75\lib\Xamarin.iOS10\TabStrip.FormsPlugin.iOS.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Xamarin.Forms.2.4.0.18342\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>

--- a/Sample/TabStrip.Sample.iOS/packages.config
+++ b/Sample/TabStrip.Sample.iOS/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="TabStrip" version="1.0.70" targetFramework="xamarinios10" />
+  <package id="TabStrip" version="1.0.75" targetFramework="xamarinios10" />
   <package id="Xamarin.Forms" version="2.4.0.18342" targetFramework="xamarinios10" />
 </packages>

--- a/Sample/TabStrip.Sample/HelloPageModel.cs
+++ b/Sample/TabStrip.Sample/HelloPageModel.cs
@@ -1,0 +1,8 @@
+﻿using TabStrip.FormsPlugin.Abstractions;
+
+namespace TabStrip.Sample
+{
+    public class HelloPageModel : PageModelBase
+    {
+    }
+}

--- a/Sample/TabStrip.Sample/HelloPageModel.cs
+++ b/Sample/TabStrip.Sample/HelloPageModel.cs
@@ -1,8 +1,0 @@
-﻿using TabStrip.FormsPlugin.Abstractions;
-
-namespace TabStrip.Sample
-{
-    public class HelloPageModel : PageModelBase
-    {
-    }
-}

--- a/Sample/TabStrip.Sample/HelloView.xaml
+++ b/Sample/TabStrip.Sample/HelloView.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="TabStrip.FormsPlugin.Abstractions.HelloView">
+             x:Class="TabStrip.Sample.HelloView">
     <ContentView.Content>
         <StackLayout>
             <Label Text="Tab Strip"

--- a/Sample/TabStrip.Sample/HelloView.xaml.cs
+++ b/Sample/TabStrip.Sample/HelloView.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Forms;
+﻿using TabStrip.FormsPlugin.Abstractions;
+using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace TabStrip.Sample

--- a/Sample/TabStrip.Sample/HelloView.xaml.cs
+++ b/Sample/TabStrip.Sample/HelloView.xaml.cs
@@ -11,4 +11,6 @@ namespace TabStrip.Sample
 			InitializeComponent ();
 		}
 	}
+
+    public class HelloPageModel { }
 }

--- a/Sample/TabStrip.Sample/HelloView.xaml.cs
+++ b/Sample/TabStrip.Sample/HelloView.xaml.cs
@@ -1,7 +1,7 @@
 ﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
-namespace TabStrip.FormsPlugin.Abstractions
+namespace TabStrip.Sample
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class HelloView : ContentView

--- a/Sample/TabStrip.Sample/MainPage.xaml
+++ b/Sample/TabStrip.Sample/MainPage.xaml
@@ -5,6 +5,7 @@
              xmlns:plugin="clr-namespace:TabStrip.FormsPlugin.Abstractions;assembly=TabStrip.FormsPlugin.Abstractions"
              x:Class="TabStrip.Sample.MainPage">
     <ContentPage.Content>
-        <plugin:TabStripControl Position="2" />
+        <plugin:TabStripControl Position="{Binding Position}"
+                                ItemsSource="{Binding Data}" />
     </ContentPage.Content>
 </ContentPage>

--- a/Sample/TabStrip.Sample/MainPage.xaml.cs
+++ b/Sample/TabStrip.Sample/MainPage.xaml.cs
@@ -1,12 +1,57 @@
 ﻿using Xamarin.Forms;
+using TabStrip.FormsPlugin.Abstractions;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
 
 namespace TabStrip.Sample
 {
     public partial class MainPage : ContentPage
 	{
+        public class Context
+        {
+            public Context()
+            {                
+                Data = new ObservableCollection<TabModel>(new[]
+                {
+                    new TabModel
+                    {
+                        Name = "Tab 1",
+                        View = (new HelloView(), new HelloPageModel())
+                    },
+                    new TabModel
+                    {
+                        Name = "Tab 2",
+                        View = (new HelloView(), new HelloPageModel())
+                    },
+                    new TabModel
+                    {
+                        Name = "Tab 3",
+                        View = (new HelloView(), new HelloPageModel())
+                    },
+                    new TabModel
+                    {
+                        Name = "Tab 4",
+                        View = (new HelloView(), new HelloPageModel())
+                    },
+                    new TabModel
+                    {
+                        Name = "Tab 5",
+                        View = (new HelloView(), new HelloPageModel())
+                    }
+                });
+                Position = 2;
+                Title = "This is a test title";
+            }
+
+            public string Title { get; set; }
+            public int Position { get; set; }
+            public ObservableCollection<TabModel> Data { get; set; }            
+        }
+
 		public MainPage()
 		{
 			InitializeComponent();
-		}
+            BindingContext = new Context();
+        }
 	}
 }

--- a/Sample/TabStrip.Sample/MainPage.xaml.cs
+++ b/Sample/TabStrip.Sample/MainPage.xaml.cs
@@ -1,7 +1,6 @@
-﻿using Xamarin.Forms;
+﻿using System.Collections.ObjectModel;
 using TabStrip.FormsPlugin.Abstractions;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
+using Xamarin.Forms;
 
 namespace TabStrip.Sample
 {

--- a/Sample/TabStrip.Sample/TabStrip.Sample.projitems
+++ b/Sample/TabStrip.Sample/TabStrip.Sample.projitems
@@ -12,7 +12,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)HelloPageModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HelloView.xaml.cs">
       <SubType>Code</SubType>
       <DependentUpon>%(Filename)</DependentUpon>

--- a/Sample/TabStrip.Sample/TabStrip.Sample.projitems
+++ b/Sample/TabStrip.Sample/TabStrip.Sample.projitems
@@ -12,11 +12,20 @@
     <Compile Include="$(MSBuildThisFileDirectory)App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)HelloPageModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HelloView.xaml.cs">
+      <SubType>Code</SubType>
+      <DependentUpon>%(Filename)</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)HelloView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)MainPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>

--- a/src/TabStrip.FormsPlugin.Abstractions/PageModelBase.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/PageModelBase.cs
@@ -2,7 +2,7 @@
 
 namespace TabStrip.FormsPlugin.Abstractions
 {
-    public class PageModelBase : INotifyPropertyChanged
+    internal class PageModelBase : INotifyPropertyChanged
     {
         public event PropertyChangedEventHandler PropertyChanged;
         public void RaisePropertyChanged(string name)

--- a/src/TabStrip.FormsPlugin.Abstractions/PageModelBase.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/PageModelBase.cs
@@ -2,7 +2,7 @@
 
 namespace TabStrip.FormsPlugin.Abstractions
 {
-    internal class PageModelBase : INotifyPropertyChanged
+    public class PageModelBase : INotifyPropertyChanged
     {
         public event PropertyChangedEventHandler PropertyChanged;
         public void RaisePropertyChanged(string name)

--- a/src/TabStrip.FormsPlugin.Abstractions/TabModel.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabModel.cs
@@ -1,0 +1,20 @@
+﻿using Xamarin.Forms;
+
+namespace TabStrip.FormsPlugin.Abstractions
+{
+    public class TabModel
+    {
+        public string Name { get; set; }
+
+        private (View, PageModelBase) _view;
+        public (View, PageModelBase) View
+        {
+            get { return _view; }
+            set
+            {
+                _view = value;
+                _view.Item1.BindingContext = _view.Item2;
+            }
+        }
+    }
+}

--- a/src/TabStrip.FormsPlugin.Abstractions/TabModel.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabModel.cs
@@ -6,8 +6,8 @@ namespace TabStrip.FormsPlugin.Abstractions
     {
         public string Name { get; set; }
 
-        private (View, PageModelBase) _view;
-        public (View, PageModelBase) View
+        private (View, object) _view;
+        public (View, object) View
         {
             get { return _view; }
             set

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStrip.FormsPlugin.Abstractions.csproj
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStrip.FormsPlugin.Abstractions.csproj
@@ -15,4 +15,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\CarouselView\CarouselView.FormsPlugin.Abstractions\CarouselView.FormsPlugin.Abstractions.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Update="TabStripTopBarControl.xaml.cs">
+      <DependentUpon>TabStripTopBarControl.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripControl.xaml
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripControl.xaml
@@ -3,19 +3,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:TabStrip.FormsPlugin.Abstractions"
              xmlns:cv="clr-namespace:CarouselView.FormsPlugin.Abstractions;assembly=CarouselView.FormsPlugin.Abstractions"
-             x:Class="TabStrip.FormsPlugin.Abstractions.TabStripControl"
-             x:Name="Control">
-    <ContentView.Resources>
-        <ResourceDictionary>
-            <DataTemplate x:Key="ViewTemplate">
-                <local:HelloView BindingContext="{Binding BindingContext.ViewModel}" />
-            </DataTemplate>
-        </ResourceDictionary>
-    </ContentView.Resources>
+             x:Class="TabStrip.FormsPlugin.Abstractions.TabStripControl">
     <ContentView.Content>
         <StackLayout>
             <Grid>
                 <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
@@ -29,7 +22,7 @@
                     Text="Image">
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer Command="{Binding SlideToTab}"
-                                            CommandParameter="0" />
+                                              CommandParameter="0" />
                     </Label.GestureRecognizers>
                 </Label>
                 <Label Grid.Column="1"
@@ -37,7 +30,7 @@
                     Text="Image">
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer Command="{Binding SlideToTab}"
-                                            CommandParameter="1" />
+                                              CommandParameter="1" />
                     </Label.GestureRecognizers>
                 </Label>
                 <Label Grid.Column="2"
@@ -45,44 +38,51 @@
                     Text="Image">
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer Command="{Binding SlideToTab}"
-                                            CommandParameter="2" />
+                                              CommandParameter="2" />
+                    </Label.GestureRecognizers>
+                </Label>
+                <Label Grid.Column="3"
+                    Grid.Row="0"
+                    Text="Image">
+                    <Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding SlideToTab}"
+                                              CommandParameter="3" />
                     </Label.GestureRecognizers>
                 </Label>
                 <BoxView Grid.Column="{Binding TabPosition}"
-                        Grid.Row="1"
-                        HeightRequest="2"
-                        BackgroundColor="Black"
-                        HorizontalOptions="FillAndExpand" />
+                         Grid.Row="1"
+                         HeightRequest="2"
+                         BackgroundColor="Black"
+                         HorizontalOptions="FillAndExpand" />
             </Grid>
             <Grid VerticalOptions="FillAndExpand"
-                HorizontalOptions="FillAndExpand">
+                  HorizontalOptions="FillAndExpand">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-                <cv:CarouselViewControl x:Name="carousel"
-                                    Grid.Column="0"
-                                    ItemsSource="{Binding Tabs}"
-                                    Position="{Binding TabPosition}"
-                                    Orientation="Horizontal"
-                                    IsSwipingEnabled="False"
-                                    VerticalOptions="FillAndExpand"
-                                    HorizontalOptions="FillAndExpand"
-                                    ItemTemplate="{StaticResource ViewTemplate}" />
+                <cv:CarouselViewControl x:Name="Carousel"
+                                        Grid.Column="0"
+                                        ItemsSource="{Binding Tabs}"
+                                        Position="{Binding TabPosition}"
+                                        Orientation="Horizontal"
+                                        IsSwipingEnabled="False"
+                                        VerticalOptions="FillAndExpand"
+                                        HorizontalOptions="FillAndExpand"/>
                 <StackLayout VerticalOptions="CenterAndExpand"
-                            HorizontalOptions="StartAndExpand"
-                            IsVisible="{Binding HasPrevious}">
+                             HorizontalOptions="StartAndExpand"
+                             IsVisible="{Binding HasPrevious}">
                     <StackLayout.GestureRecognizers>
                         <TapGestureRecognizer Command="{Binding SlideTab}"
-                                            CommandParameter="-1" />
+                                              CommandParameter="-1" />
                     </StackLayout.GestureRecognizers>
                     <Label Text="P" />
                 </StackLayout>
                 <StackLayout VerticalOptions="CenterAndExpand"
-                            HorizontalOptions="EndAndExpand"
-                            IsVisible="{Binding HasNext}">
+                             HorizontalOptions="EndAndExpand"
+                             IsVisible="{Binding HasNext}">
                     <StackLayout.GestureRecognizers>
                         <TapGestureRecognizer Command="{Binding SlideTab}"
-                                            CommandParameter="1"/>
+                                              CommandParameter="1"/>
                     </StackLayout.GestureRecognizers>
                     <Label Text="N" />
                 </StackLayout>

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripControl.xaml
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripControl.xaml
@@ -3,10 +3,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:TabStrip.FormsPlugin.Abstractions"
              xmlns:cv="clr-namespace:CarouselView.FormsPlugin.Abstractions;assembly=CarouselView.FormsPlugin.Abstractions"
-             x:Class="TabStrip.FormsPlugin.Abstractions.TabStripControl">
+             x:Class="TabStrip.FormsPlugin.Abstractions.TabStripControl"
+             x:Name="this">
     <ContentView.Content>
         <StackLayout>
-            <local:TabStripTopBarControl BindingContext="{Binding .}" />
+            <local:TabStripTopBarControl BindingContext="{Binding Source={x:Reference this},
+                                                                  Path=ViewModel}" />
             <Grid VerticalOptions="FillAndExpand"
                   HorizontalOptions="FillAndExpand">
                 <Grid.ColumnDefinitions>
@@ -14,26 +16,32 @@
                 </Grid.ColumnDefinitions>
                 <cv:CarouselViewControl x:Name="Carousel"
                                         Grid.Column="0"
-                                        ItemsSource="{Binding Tabs}"
-                                        Position="{Binding TabPosition}"
+                                        ItemsSource="{Binding Source={x:Reference this},
+                                                              Path=ViewModel.Tabs}"
+                                        Position="{Binding Source={x:Reference this},
+                                                           Path=ViewModel.TabPosition}"
                                         Orientation="Horizontal"
                                         IsSwipingEnabled="False"
                                         VerticalOptions="FillAndExpand"
                                         HorizontalOptions="FillAndExpand"/>
                 <StackLayout VerticalOptions="CenterAndExpand"
                              HorizontalOptions="StartAndExpand"
-                             IsVisible="{Binding HasPrevious}">
+                             IsVisible="{Binding Source={x:Reference this}, 
+                                                 Path=ViewModel.HasPrevious}">
                     <StackLayout.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding SlideTab}"
+                        <TapGestureRecognizer Command="{Binding Source={x:Reference this},
+                                                                Path=ViewModel.SlideTab}"
                                               CommandParameter="-1" />
                     </StackLayout.GestureRecognizers>
                     <Label Text="P" />
                 </StackLayout>
                 <StackLayout VerticalOptions="CenterAndExpand"
                              HorizontalOptions="EndAndExpand"
-                             IsVisible="{Binding HasNext}">
+                             IsVisible="{Binding Source={x:Reference this},
+                                                 Path=ViewModel.HasNext}">
                     <StackLayout.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding SlideTab}"
+                        <TapGestureRecognizer Command="{Binding Source={x:Reference this},
+                                                                Path=ViewModel.SlideTab}"
                                               CommandParameter="1"/>
                     </StackLayout.GestureRecognizers>
                     <Label Text="N" />

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripControl.xaml
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripControl.xaml
@@ -6,55 +6,7 @@
              x:Class="TabStrip.FormsPlugin.Abstractions.TabStripControl">
     <ContentView.Content>
         <StackLayout>
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="*" />
-                    <RowDefinition Height="2" />
-                </Grid.RowDefinitions>
-                <Label Grid.Column="0"
-                    Grid.Row="0"
-                    Text="Image">
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding SlideToTab}"
-                                              CommandParameter="0" />
-                    </Label.GestureRecognizers>
-                </Label>
-                <Label Grid.Column="1"
-                    Grid.Row="0"
-                    Text="Image">
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding SlideToTab}"
-                                              CommandParameter="1" />
-                    </Label.GestureRecognizers>
-                </Label>
-                <Label Grid.Column="2"
-                    Grid.Row="0"
-                    Text="Image">
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding SlideToTab}"
-                                              CommandParameter="2" />
-                    </Label.GestureRecognizers>
-                </Label>
-                <Label Grid.Column="3"
-                    Grid.Row="0"
-                    Text="Image">
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding SlideToTab}"
-                                              CommandParameter="3" />
-                    </Label.GestureRecognizers>
-                </Label>
-                <BoxView Grid.Column="{Binding TabPosition}"
-                         Grid.Row="1"
-                         HeightRequest="2"
-                         BackgroundColor="Black"
-                         HorizontalOptions="FillAndExpand" />
-            </Grid>
+            <local:TabStripTopBarControl BindingContext="{Binding .}" />
             <Grid VerticalOptions="FillAndExpand"
                   HorizontalOptions="FillAndExpand">
                 <Grid.ColumnDefinitions>

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripControl.xaml.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripControl.xaml.cs
@@ -1,38 +1,38 @@
-﻿using System.ComponentModel;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace TabStrip.FormsPlugin.Abstractions
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
-    public partial class TabStripControl : ContentView, INotifyPropertyChanged
+    public partial class TabStripControl : ContentView
     {
-        public TabStripControl(bool init) { }
-
+        public TabStripControlModel ViewModel { get; set; }
         public TabStripControl()
         {
             InitializeComponent();
-            var context = new TabStripControlModel();
-            BindingContext = context;
-            Carousel.ItemTemplate = new TabViewSelector(context.Tabs);
+            Position = 0;
+
+            ViewModel = new TabStripControlModel();
         }
 
         public static readonly BindableProperty PositionProperty = BindableProperty.Create(
             "Position",
-            typeof(int), 
-            typeof(TabStripControl), 
+            typeof(int),
+            typeof(TabStripControl),
             0,
-            BindingMode.TwoWay, 
-            null, 
+            BindingMode.TwoWay,
+            null,
             OnPositionChanged);
 
         private static void OnPositionChanged(BindableObject bindable, object oldValue, object newValue)
         {
             var control = (TabStripControl)bindable;
-            
             if (control != null)
-            {                   
-                (control.BindingContext as TabStripControlModel).TabPosition = (int)newValue;
+            {
+                control.ViewModel.TabPosition = (int)newValue;
             }
         }
 
@@ -40,6 +40,31 @@ namespace TabStrip.FormsPlugin.Abstractions
         {
             get { return (int)GetValue(PositionProperty); }
             set { SetValue(PositionProperty, value); }
+        }
+
+        public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(
+            "ItemsSource",
+            typeof(IEnumerable),
+            typeof(TabStripControl),
+            null,
+            propertyChanged: OnItemsSourceChanged);
+
+        private static void OnItemsSourceChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var control = (TabStripControl)bindable;
+
+            if (control != null)
+            {
+                var tabs = (IEnumerable<TabModel>)newValue;
+                control.Carousel.ItemTemplate = new TabViewSelector(tabs);
+                control.ViewModel.Tabs = new ObservableCollection<TabModel>(tabs);
+            }
+        }
+
+        public IEnumerable ItemsSource
+        {
+            get { return (IEnumerable)GetValue(ItemsSourceProperty); }
+            set { SetValue(ItemsSourceProperty, value); }
         }
     }
 }

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripControl.xaml.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripControl.xaml.cs
@@ -9,7 +9,7 @@ namespace TabStrip.FormsPlugin.Abstractions
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class TabStripControl : ContentView
     {
-        public TabStripControlModel ViewModel { get; set; }
+        internal TabStripControlModel ViewModel { get; set; }
         public TabStripControl()
         {
             InitializeComponent();

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripControl.xaml.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripControl.xaml.cs
@@ -9,7 +9,7 @@ namespace TabStrip.FormsPlugin.Abstractions
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class TabStripControl : ContentView
     {
-        internal TabStripControlModel ViewModel { get; set; }
+        public TabStripControlModel ViewModel { get; set; }
         public TabStripControl()
         {
             InitializeComponent();

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripControl.xaml.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripControl.xaml.cs
@@ -12,10 +12,19 @@ namespace TabStrip.FormsPlugin.Abstractions
         public TabStripControl()
         {
             InitializeComponent();
-            BindingContext = new TabStripControlModel();
+            var context = new TabStripControlModel();
+            BindingContext = context;
+            Carousel.ItemTemplate = new TabViewSelector(context.Tabs);
         }
 
-        public static readonly BindableProperty PositionProperty = BindableProperty.Create("Position", typeof(int), typeof(TabStripControl), 0, BindingMode.TwoWay, null, OnPositionChanged);
+        public static readonly BindableProperty PositionProperty = BindableProperty.Create(
+            "Position",
+            typeof(int), 
+            typeof(TabStripControl), 
+            0,
+            BindingMode.TwoWay, 
+            null, 
+            OnPositionChanged);
 
         private static void OnPositionChanged(BindableObject bindable, object oldValue, object newValue)
         {

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripControlModel.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripControlModel.cs
@@ -4,34 +4,12 @@ using Xamarin.Forms;
 
 namespace TabStrip.FormsPlugin.Abstractions
 {
-    internal class HelloPageModel : PageModelBase { }
-    internal class TabStripControlModel : PageModelBase
+    public class HelloPageModel : PageModelBase { }
+    public class TabStripControlModel : PageModelBase
     {
         public TabStripControlModel()
         {
-            Tabs = new ObservableCollection<TabModel>
-            {
-                new TabModel
-                {
-                    Name = "Tab 1",
-                    View = (new HelloView(), new HelloPageModel())
-                },
-                new TabModel
-                {
-                    Name = "Tab 2",
-                    View = (new HelloView(), new HelloPageModel())
-                },
-                new TabModel
-                {
-                    Name = "Tab 3",
-                    View = (new HelloView(), new HelloPageModel())
-                },
-                new TabModel
-                {
-                    Name = "Tab 4",
-                    View = (new HelloView(), new HelloPageModel())
-                },
-            };
+            Tabs = new ObservableCollection<TabModel>();
             TabPosition = 0;
             SlideTab = new Command<string>(OnSlideTab);
             SlideToTab = new Command<string>(OnSlideToTab);
@@ -61,7 +39,17 @@ namespace TabStrip.FormsPlugin.Abstractions
                 RaisePropertyChanged(nameof(HasPrevious));
             }
         }
-        public ObservableCollection<TabModel> Tabs { get; set; }
+
+        private ObservableCollection<TabModel> _tabs;
+        public ObservableCollection<TabModel> Tabs
+        {
+            get { return _tabs; }
+            set
+            {
+                _tabs = value;
+                RaisePropertyChanged(nameof(Tabs));
+            }
+        }
 
         private int _tabPosition;
         public int TabPosition

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripControlModel.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripControlModel.cs
@@ -4,8 +4,7 @@ using Xamarin.Forms;
 
 namespace TabStrip.FormsPlugin.Abstractions
 {
-    public class HelloPageModel : PageModelBase { }
-    public class TabStripControlModel : PageModelBase
+    internal class TabStripControlModel : PageModelBase
     {
         public TabStripControlModel()
         {

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripControlModel.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripControlModel.cs
@@ -9,11 +9,28 @@ namespace TabStrip.FormsPlugin.Abstractions
     {
         public TabStripControlModel()
         {
-            Tabs = new ObservableCollection<PageModelBase>
+            Tabs = new ObservableCollection<TabModel>
             {
-                new HelloPageModel(),
-                new HelloPageModel(),
-                new HelloPageModel()
+                new TabModel
+                {
+                    Name = "Tab 1",
+                    View = (new HelloView(), new HelloPageModel())
+                },
+                new TabModel
+                {
+                    Name = "Tab 2",
+                    View = (new HelloView(), new HelloPageModel())
+                },
+                new TabModel
+                {
+                    Name = "Tab 3",
+                    View = (new HelloView(), new HelloPageModel())
+                },
+                new TabModel
+                {
+                    Name = "Tab 4",
+                    View = (new HelloView(), new HelloPageModel())
+                },
             };
             TabPosition = 0;
             SlideTab = new Command<string>(OnSlideTab);
@@ -44,7 +61,7 @@ namespace TabStrip.FormsPlugin.Abstractions
                 RaisePropertyChanged(nameof(HasPrevious));
             }
         }
-        public ObservableCollection<PageModelBase> Tabs { get; set; }
+        public ObservableCollection<TabModel> Tabs { get; set; }
 
         private int _tabPosition;
         public int TabPosition
@@ -68,7 +85,6 @@ namespace TabStrip.FormsPlugin.Abstractions
         private void OnSlideToTab(string position)
         {
             TabPosition = int.Parse(position);
-
         }
     }
 }

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripControlModel.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripControlModel.cs
@@ -4,7 +4,7 @@ using Xamarin.Forms;
 
 namespace TabStrip.FormsPlugin.Abstractions
 {
-    internal class TabStripControlModel : PageModelBase
+    public class TabStripControlModel : PageModelBase
     {
         public TabStripControlModel()
         {

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml
@@ -1,70 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:TabStrip.FormsPlugin.Abstractions"
              x:Class="TabStrip.FormsPlugin.Abstractions.TabStripTopBarControl">
   <ContentView.Content>
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*" />
-                <RowDefinition Height="2" />
-            </Grid.RowDefinitions>
-            <!--<cv:CarouselViewControl Grid.Row="0"
-                                        Orientation="Horizontal"
-                                        ItemsSource="{Binding Tabs}">
-                <cv:CarouselViewControl.ItemTemplate>
-                    <DataTemplate>
-                        <Label Text="{Binding Name}">
-                            --><!--<Label.GestureRecognizers>
-                                    <TapGestureRecognizer Command="{Binding Parent.SlideToTab}"
-                                                            CommandParameter="0" />
-                                </Label.GestureRecognizers>--><!--
-                        </Label>
-                    </DataTemplate>
-                </cv:CarouselViewControl.ItemTemplate>
-            </cv:CarouselViewControl>-->
-            <Label Grid.Column="0"
-                    Grid.Row="0"
-                    Text="Image">
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding SlideToTab}"
-                                              CommandParameter="0" />
-                    </Label.GestureRecognizers>
-                </Label>
-                <Label Grid.Column="1"
-                    Grid.Row="0"
-                    Text="Image">
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding SlideToTab}"
-                                              CommandParameter="1" />
-                    </Label.GestureRecognizers>
-                </Label>
-                <Label Grid.Column="2"
-                    Grid.Row="0"
-                    Text="Image">
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding SlideToTab}"
-                                              CommandParameter="2" />
-                    </Label.GestureRecognizers>
-                </Label>
-                <Label Grid.Column="3"
-                    Grid.Row="0"
-                    Text="Image">
-                    <Label.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding SlideToTab}"
-                                              CommandParameter="3" />
-                    </Label.GestureRecognizers>
-                </Label>
-            <BoxView Grid.Column="{Binding TabPosition}"
-                         Grid.Row="1"
-                         HeightRequest="2"
-                         BackgroundColor="Black"
-                         HorizontalOptions="FillAndExpand" />
-        </Grid>
+        
     </ContentView.Content>
 </ContentView>

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TabStrip.FormsPlugin.Abstractions.TabStripTopBarControl">
+  <ContentView.Content>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="2" />
+            </Grid.RowDefinitions>
+            <!--<cv:CarouselViewControl Grid.Row="0"
+                                        Orientation="Horizontal"
+                                        ItemsSource="{Binding Tabs}">
+                <cv:CarouselViewControl.ItemTemplate>
+                    <DataTemplate>
+                        <Label Text="{Binding Name}">
+                            --><!--<Label.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding Parent.SlideToTab}"
+                                                            CommandParameter="0" />
+                                </Label.GestureRecognizers>--><!--
+                        </Label>
+                    </DataTemplate>
+                </cv:CarouselViewControl.ItemTemplate>
+            </cv:CarouselViewControl>-->
+            <Label Grid.Column="0"
+                    Grid.Row="0"
+                    Text="Image">
+                    <Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding SlideToTab}"
+                                              CommandParameter="0" />
+                    </Label.GestureRecognizers>
+                </Label>
+                <Label Grid.Column="1"
+                    Grid.Row="0"
+                    Text="Image">
+                    <Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding SlideToTab}"
+                                              CommandParameter="1" />
+                    </Label.GestureRecognizers>
+                </Label>
+                <Label Grid.Column="2"
+                    Grid.Row="0"
+                    Text="Image">
+                    <Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding SlideToTab}"
+                                              CommandParameter="2" />
+                    </Label.GestureRecognizers>
+                </Label>
+                <Label Grid.Column="3"
+                    Grid.Row="0"
+                    Text="Image">
+                    <Label.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding SlideToTab}"
+                                              CommandParameter="3" />
+                    </Label.GestureRecognizers>
+                </Label>
+            <BoxView Grid.Column="{Binding TabPosition}"
+                         Grid.Row="1"
+                         HeightRequest="2"
+                         BackgroundColor="Black"
+                         HorizontalOptions="FillAndExpand" />
+        </Grid>
+    </ContentView.Content>
+</ContentView>

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace TabStrip.FormsPlugin.Abstractions
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class TabStripTopBarControl : ContentView
+	{
+		public TabStripTopBarControl()
+		{
+			InitializeComponent ();
+		}
+	}
+}

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Forms;
+﻿using System;
+using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace TabStrip.FormsPlugin.Abstractions
@@ -22,11 +23,10 @@ namespace TabStrip.FormsPlugin.Abstractions
                 {
                     Text = context.Tabs[index].Name
                 };
-
-                // TODO - there is an issue with the tap gesture not picking up
+                
                 var tapGestureRecognizer = new TapGestureRecognizer();
-                tapGestureRecognizer.SetBinding(TapGestureRecognizer.CommandProperty, new Binding("SlideToTab"));
-                tapGestureRecognizer.CommandParameter = index;
+                tapGestureRecognizer.Command = context.SlideToTab;
+                tapGestureRecognizer.CommandParameter = Convert.ToString(index);
                 label.GestureRecognizers.Add(tapGestureRecognizer);
 
                 grid.Children.Add(label, index, 0);

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml.cs
@@ -10,5 +10,41 @@ namespace TabStrip.FormsPlugin.Abstractions
 		{
 			InitializeComponent ();
 		}
-	}
+
+        protected override void OnBindingContextChanged()
+        {
+            var context = (TabStripControlModel)BindingContext;
+            var grid = new Grid();
+            for (int index = 0; index < context.Tabs.Count; index++)
+            {
+                grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                var label = new Label
+                {
+                    Text = context.Tabs[index].Name
+                };
+
+                // TODO - there is an issue with the tap gesture not picking up
+                var tapGestureRecognizer = new TapGestureRecognizer();
+                tapGestureRecognizer.SetBinding(TapGestureRecognizer.CommandProperty, new Binding("SlideToTab"));
+                tapGestureRecognizer.CommandParameter = index;
+                label.GestureRecognizers.Add(tapGestureRecognizer);
+
+                grid.Children.Add(label, index, 0);
+            }
+
+            grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+            grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(2) });
+
+            var boxView = new BoxView
+            {
+                HeightRequest = 2,
+                BackgroundColor = new Color(0, 0, 0),
+                HorizontalOptions = new LayoutOptions(LayoutAlignment.Fill, true)
+            };
+            grid.Children.Add(boxView, context.TabPosition, 1);
+            boxView.SetBinding(Grid.ColumnProperty, new Binding("TabPosition"));
+
+            Content = grid;
+        }
+    }
 }

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml.cs
@@ -15,6 +15,8 @@ namespace TabStrip.FormsPlugin.Abstractions
         protected override void OnBindingContextChanged()
         {
             var context = (TabStripControlModel)BindingContext;
+            if (context?.Tabs == null) return;
+
             var grid = new Grid();
             for (int index = 0; index < context.Tabs.Count; index++)
             {

--- a/src/TabStrip.FormsPlugin.Abstractions/TabViewSelector.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabViewSelector.cs
@@ -3,7 +3,7 @@ using Xamarin.Forms;
 
 namespace TabStrip.FormsPlugin.Abstractions
 {
-    public class TabViewSelector : DataTemplateSelector
+    internal class TabViewSelector : DataTemplateSelector
     {
         private readonly IDictionary<string, DataTemplate> _templates;
 

--- a/src/TabStrip.FormsPlugin.Abstractions/TabViewSelector.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabViewSelector.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms;
+
+namespace TabStrip.FormsPlugin.Abstractions
+{
+    public class TabViewSelector : DataTemplateSelector
+    {
+        private readonly IDictionary<string, DataTemplate> _templates;
+
+        public TabViewSelector(IEnumerable<TabModel> tabs)
+        {
+            _templates = new Dictionary<string, DataTemplate>();
+            foreach (var item in tabs)
+                _templates.Add(item.Name, new DataTemplate(() => new ContentView { Content = item.View.Item1 }));
+        }
+
+        protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+        {            
+            var tab = (TabModel)item;
+            return _templates[tab.Name];
+        }
+    }
+}

--- a/src/TabStrip.FormsPlugin.Android/TabStripImplementation.cs
+++ b/src/TabStrip.FormsPlugin.Android/TabStripImplementation.cs
@@ -16,7 +16,7 @@ namespace TabStrip.FormsPlugin.Android
         public static void Init()
         {
             CarouselViewRenderer.Init();
-            var dummy = new TabStripControl(true);
+            var dummy = new TabStripControl();
         }
     }
 }

--- a/src/TabStrip.FormsPlugin.iOS/TabStripImplementation.cs
+++ b/src/TabStrip.FormsPlugin.iOS/TabStripImplementation.cs
@@ -16,7 +16,7 @@ namespace TabStrip.FormsPlugin.iOS
         public static void Init()
         {
             CarouselViewRenderer.Init();
-            var dummy = new TabStripControl(true);
+            var dummy = new TabStripControl();
         }
     }
 }


### PR DESCRIPTION
Added BindableProperty ItemsSource to the TabStripControl. The ItemsSource takes an `IEnumerable` that is of `TabModel` which is obtained from the abstractions project

```C#
public class TabModel
{
    public string Name { get; set; }
    public (View, object) View { get; set; }
}
```

The `Name` in the `TabModel` will be displayed in the name of each tab and the Tuple currently renders the `View` in the view of the tab where the `object` is the ViewModel (which isn't currently wired up).

XAML:
```xml
<plugin:TabStripControl Position="{Binding Position}" ItemsSource="{Binding Data}" />
```

C#:
```c#
BindingContext = new 
{
    Position = 0,
    Data = new ObservableCollection<TabModel>(new []
    {
        new TabModel
        {
            Name = "Tab 1",
            View = (new HelloView(), new HelloPageModel())
        },
        new TabModel
        {
            Name = "Tab 2",
            View = (new HelloView(), new HelloPageModel())
        }
    });
}
```
