### PR TITLE
Tab Header Customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ BindingContext = new
 	{
 		new TabModel
         {
-            Name = "Tab 1",
+            Header = (new HeaderView(), new { Title = "Tab 1" }),
             View = (new HelloView(), new HelloPageModel())
         },
         new TabModel
         {
-            Name = "Tab 2",
+            Header = (new HeaderView(), new { Title = "Tab 2" }),
             View = (new HelloView(), new HelloPageModel())
         }
 

--- a/Sample/TabStrip.Sample.Android/TabStrip.Sample.Android.csproj
+++ b/Sample/TabStrip.Sample.Android/TabStrip.Sample.Android.csproj
@@ -50,10 +50,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CarouselView.FormsPlugin.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.75\lib\MonoAndroid10\CarouselView.FormsPlugin.Abstractions.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.79\lib\MonoAndroid10\CarouselView.FormsPlugin.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="CarouselView.FormsPlugin.Android, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.75\lib\MonoAndroid10\CarouselView.FormsPlugin.Android.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.79\lib\MonoAndroid10\CarouselView.FormsPlugin.Android.dll</HintPath>
     </Reference>
     <Reference Include="FormsViewGroup, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Xamarin.Forms.2.4.0.18342\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
@@ -65,10 +65,10 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
     <Reference Include="TabStrip.FormsPlugin.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.75\lib\MonoAndroid10\TabStrip.FormsPlugin.Abstractions.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.79\lib\MonoAndroid10\TabStrip.FormsPlugin.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="TabStrip.FormsPlugin.Android, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.75\lib\MonoAndroid10\TabStrip.FormsPlugin.Android.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.79\lib\MonoAndroid10\TabStrip.FormsPlugin.Android.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Android.Support.Animated.Vector.Drawable, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.26.0.2\lib\MonoAndroid80\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>

--- a/Sample/TabStrip.Sample.Android/packages.config
+++ b/Sample/TabStrip.Sample.Android/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="TabStrip" version="1.0.75" targetFramework="monoandroid80" />
+  <package id="TabStrip" version="1.0.79" targetFramework="monoandroid80" />
   <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="26.0.2" targetFramework="monoandroid80" />
   <package id="Xamarin.Android.Support.Annotations" version="26.0.2" targetFramework="monoandroid80" />
   <package id="Xamarin.Android.Support.Compat" version="26.0.2" targetFramework="monoandroid80" />

--- a/Sample/TabStrip.Sample.iOS/TabStrip.Sample.iOS.csproj
+++ b/Sample/TabStrip.Sample.iOS/TabStrip.Sample.iOS.csproj
@@ -122,19 +122,19 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="CarouselView.FormsPlugin.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.75\lib\Xamarin.iOS10\CarouselView.FormsPlugin.Abstractions.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.79\lib\Xamarin.iOS10\CarouselView.FormsPlugin.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="CarouselView.FormsPlugin.iOS, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.75\lib\Xamarin.iOS10\CarouselView.FormsPlugin.iOS.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.79\lib\Xamarin.iOS10\CarouselView.FormsPlugin.iOS.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="TabStrip.FormsPlugin.Abstractions, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.75\lib\Xamarin.iOS10\TabStrip.FormsPlugin.Abstractions.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.79\lib\Xamarin.iOS10\TabStrip.FormsPlugin.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="TabStrip.FormsPlugin.iOS, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\TabStrip.1.0.75\lib\Xamarin.iOS10\TabStrip.FormsPlugin.iOS.dll</HintPath>
+      <HintPath>..\..\packages\TabStrip.1.0.79\lib\Xamarin.iOS10\TabStrip.FormsPlugin.iOS.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Xamarin.Forms.2.4.0.18342\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>

--- a/Sample/TabStrip.Sample.iOS/packages.config
+++ b/Sample/TabStrip.Sample.iOS/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="TabStrip" version="1.0.75" targetFramework="xamarinios10" />
+  <package id="TabStrip" version="1.0.79" targetFramework="xamarinios10" />
   <package id="Xamarin.Forms" version="2.4.0.18342" targetFramework="xamarinios10" />
 </packages>

--- a/Sample/TabStrip.Sample/HeaderView.xaml
+++ b/Sample/TabStrip.Sample/HeaderView.xaml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="TabStrip.Sample.HeaderView">
+  <ContentView.Content>
+      <StackLayout>
+          <Label Text="{Binding Title}" />
+      </StackLayout>
+  </ContentView.Content>
+</ContentView>

--- a/Sample/TabStrip.Sample/HeaderView.xaml
+++ b/Sample/TabStrip.Sample/HeaderView.xaml
@@ -5,6 +5,6 @@
   <ContentView.Content>
       <StackLayout>
           <Label Text="{Binding Title}" />
-      </StackLayout>
+        </StackLayout>
   </ContentView.Content>
 </ContentView>

--- a/Sample/TabStrip.Sample/HeaderView.xaml.cs
+++ b/Sample/TabStrip.Sample/HeaderView.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace TabStrip.Sample
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class HeaderView : ContentView
+	{
+		public HeaderView ()
+		{
+			InitializeComponent ();
+		}
+	}
+}

--- a/Sample/TabStrip.Sample/MainPage.xaml.cs
+++ b/Sample/TabStrip.Sample/MainPage.xaml.cs
@@ -14,27 +14,27 @@ namespace TabStrip.Sample
                 {
                     new TabModel
                     {
-                        Name = "Tab 1",
+                        Name = (new HeaderView(), new { Title = "Tab 1" }),
                         View = (new HelloView(), new HelloPageModel())
                     },
                     new TabModel
                     {
-                        Name = "Tab 2",
+                        Name = (new HeaderView(), new { Title = "Tab 2" }),
                         View = (new HelloView(), new HelloPageModel())
                     },
                     new TabModel
                     {
-                        Name = "Tab 3",
+                        Name = (new HeaderView(), new { Title = "Tab 3" }),
                         View = (new HelloView(), new HelloPageModel())
                     },
                     new TabModel
                     {
-                        Name = "Tab 4",
+                        Name = (new HeaderView(), new { Title = "Tab 4" }),
                         View = (new HelloView(), new HelloPageModel())
                     },
                     new TabModel
                     {
-                        Name = "Tab 5",
+                        Name = (new HeaderView(), new { Title = "Tab 5" }),
                         View = (new HelloView(), new HelloPageModel())
                     }
                 });

--- a/Sample/TabStrip.Sample/MainPage.xaml.cs
+++ b/Sample/TabStrip.Sample/MainPage.xaml.cs
@@ -14,27 +14,27 @@ namespace TabStrip.Sample
                 {
                     new TabModel
                     {
-                        Name = (new HeaderView(), new { Title = "Tab 1" }),
+                        Header = (new HeaderView(), new { Title = "Tab 1" }),
                         View = (new HelloView(), new HelloPageModel())
                     },
                     new TabModel
                     {
-                        Name = (new HeaderView(), new { Title = "Tab 2" }),
+                        Header = (new HeaderView(), new { Title = "Tab 2" }),
                         View = (new HelloView(), new HelloPageModel())
                     },
                     new TabModel
                     {
-                        Name = (new HeaderView(), new { Title = "Tab 3" }),
+                        Header = (new HeaderView(), new { Title = "Tab 3" }),
                         View = (new HelloView(), new HelloPageModel())
                     },
                     new TabModel
                     {
-                        Name = (new HeaderView(), new { Title = "Tab 4" }),
+                        Header = (new HeaderView(), new { Title = "Tab 4" }),
                         View = (new HelloView(), new HelloPageModel())
                     },
                     new TabModel
                     {
-                        Name = (new HeaderView(), new { Title = "Tab 5" }),
+                        Header = (new HeaderView(), new { Title = "Tab 5" }),
                         View = (new HelloView(), new HelloPageModel())
                     }
                 });

--- a/Sample/TabStrip.Sample/TabStrip.Sample.projitems
+++ b/Sample/TabStrip.Sample/TabStrip.Sample.projitems
@@ -12,6 +12,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)HeaderView.xaml.cs">
+      <DependentUpon>HeaderView.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)HelloView.xaml.cs">
       <SubType>Code</SubType>
       <DependentUpon>%(Filename)</DependentUpon>
@@ -30,6 +34,12 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)App.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)HeaderView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/TabStrip.Sample.sln
+++ b/TabStrip.Sample.sln
@@ -1,18 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26923.0
+VisualStudioVersion = 15.0.27004.2006
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "TabStrip.Sample", "Sample\TabStrip.Sample\TabStrip.Sample.shproj", "{BA6C7969-275E-486D-8B79-2CB77D8BE50E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TabStrip.Sample.Android", "Sample\TabStrip.Sample.Android\TabStrip.Sample.Android.csproj", "{55F04EA4-ABED-4F26-AA67-23945819B528}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TabStrip.Sample.iOS", "Sample\TabStrip.Sample.iOS\TabStrip.Sample.iOS.csproj", "{FC3BCD67-0433-473B-A918-87B71BDDB8C5}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{3F1CC10A-5D55-4807-95A7-92360023B188}"
-	ProjectSection(SolutionItems) = preProject
-		.nuget\NuGet.config = .nuget\NuGet.config
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution

--- a/TabStrip.sln
+++ b/TabStrip.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26923.0
+VisualStudioVersion = 15.0.27004.2006
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CarouselView", "CarouselView", "{702FB74C-3906-4114-816F-CDF1BE213071}"
 EndProject
@@ -20,6 +20,11 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{B0CCB033-4C26-49B3-97B1-4ADD88AD5992}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\TabStrip.nuspec = .nuget\TabStrip.nuspec
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".build", ".build", "{3295AB9E-5824-4085-8266-41BFB537D0B4}"
+	ProjectSection(SolutionItems) = preProject
+		build.cake = build.cake
 	EndProjectSection
 EndProject
 Global

--- a/build.cake
+++ b/build.cake
@@ -27,7 +27,8 @@ Task ("NuGet")
 });
 
 //Build the component, which build samples, nugets, and libraries
-Task ("Default").IsDependentOn("NuGet");
+Task ("Default")
+	.IsDependentOn("NuGet");
 
 Task ("Clean").Does (() => 
 {

--- a/src/TabStrip.FormsPlugin.Abstractions/TabModel.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabModel.cs
@@ -4,7 +4,7 @@ namespace TabStrip.FormsPlugin.Abstractions
 {
     public class TabModel
     {
-        public (View, object) Name { get; set; }
+        public (View, object) Header { get; set; }
 
         private (View, object) _view;
         public (View, object) View

--- a/src/TabStrip.FormsPlugin.Abstractions/TabModel.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabModel.cs
@@ -4,7 +4,7 @@ namespace TabStrip.FormsPlugin.Abstractions
 {
     public class TabModel
     {
-        public string Name { get; set; }
+        public (View, object) Name { get; set; }
 
         private (View, object) _view;
         public (View, object) View

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml.cs
@@ -21,17 +21,18 @@ namespace TabStrip.FormsPlugin.Abstractions
             for (int index = 0; index < context.Tabs.Count; index++)
             {
                 grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
-                var label = new Label
+                var view = new ContentView
                 {
-                    Text = context.Tabs[index].Name
+                    Content = context.Tabs[index].Name.Item1,
+                    BindingContext = context.Tabs[index].Name.Item2
                 };
                 
                 var tapGestureRecognizer = new TapGestureRecognizer();
                 tapGestureRecognizer.Command = context.SlideToTab;
                 tapGestureRecognizer.CommandParameter = Convert.ToString(index);
-                label.GestureRecognizers.Add(tapGestureRecognizer);
+                view.GestureRecognizers.Add(tapGestureRecognizer);
 
-                grid.Children.Add(label, index, 0);
+                grid.Children.Add(view, index, 0);
             }
 
             grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });

--- a/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabStripTopBarControl.xaml.cs
@@ -23,8 +23,8 @@ namespace TabStrip.FormsPlugin.Abstractions
                 grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
                 var view = new ContentView
                 {
-                    Content = context.Tabs[index].Name.Item1,
-                    BindingContext = context.Tabs[index].Name.Item2
+                    Content = context.Tabs[index].Header.Item1,
+                    BindingContext = context.Tabs[index].Header.Item2
                 };
                 
                 var tapGestureRecognizer = new TapGestureRecognizer();

--- a/src/TabStrip.FormsPlugin.Abstractions/TabViewSelector.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabViewSelector.cs
@@ -5,19 +5,19 @@ namespace TabStrip.FormsPlugin.Abstractions
 {
     internal class TabViewSelector : DataTemplateSelector
     {
-        private readonly IDictionary<string, DataTemplate> _templates;
+        private readonly IDictionary<View, DataTemplate> _templates;
 
         public TabViewSelector(IEnumerable<TabModel> tabs)
         {
-            _templates = new Dictionary<string, DataTemplate>();
+            _templates = new Dictionary<View, DataTemplate>();
             foreach (var item in tabs)
-                _templates.Add(item.Name, new DataTemplate(() => new ContentView { Content = item.View.Item1 }));
+                _templates.Add(item.Name.Item1, new DataTemplate(() => new ContentView { Content = item.View.Item1 }));
         }
 
         protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
         {            
             var tab = (TabModel)item;
-            return _templates[tab.Name];
+            return _templates[tab.Name.Item1];
         }
     }
 }

--- a/src/TabStrip.FormsPlugin.Abstractions/TabViewSelector.cs
+++ b/src/TabStrip.FormsPlugin.Abstractions/TabViewSelector.cs
@@ -11,13 +11,13 @@ namespace TabStrip.FormsPlugin.Abstractions
         {
             _templates = new Dictionary<View, DataTemplate>();
             foreach (var item in tabs)
-                _templates.Add(item.Name.Item1, new DataTemplate(() => new ContentView { Content = item.View.Item1 }));
+                _templates.Add(item.Header.Item1, new DataTemplate(() => new ContentView { Content = item.View.Item1 }));
         }
 
         protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
         {            
             var tab = (TabModel)item;
-            return _templates[tab.Name.Item1];
+            return _templates[tab.Header.Item1];
         }
     }
 }


### PR DESCRIPTION
Added support for Tab Header Customization. The `TabModel` is now updated to take a `View`/`ViewModel` pairing that is then injected into the TabStrip Header for each tab. This allows you to customize each Tab View individually from the others or pass in separate ViewModels